### PR TITLE
Add signature for sev-snp with hash 4e79ac8fe57393ec2932d418c23c846aed439d6145e5e1e0fbd41bdc911194e4

### DIFF
--- a/signatures/sev-snp/pre-release/mrenclave-4e79ac8fe57393ec2932d418c23c846aed439d6145e5e1e0fbd41bdc911194e4.json
+++ b/signatures/sev-snp/pre-release/mrenclave-4e79ac8fe57393ec2932d418c23c846aed439d6145e5e1e0fbd41bdc911194e4.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "4e79ac8fe57393ec2932d418c23c846aed439d6145e5e1e0fbd41bdc911194e4",
+  "signature": "Wwg8pIOI7mGMkXcDRp1UAd/9oyApjRlbO9bfPOV3AQ03nqhDnmilgTBClAgDyF6JULzKZymrDku/sUfK95av/oB5nSMgS1gJ9cIy0SrR8uldwdlh5JxAhMu+j3m4lBdBlJAavKX0a+LzLT8aVSAodeFc6kXFtFheeyPL2+BF4sY1pZ4GfSfWxCcPaKE7nYPlJMhXWlRaWmlp9dxz9IB0vlrxhyudjnvwLDBPiM/dJZHq3PqU623mZho0ovPtbbiCTUxag1EVsEceON4sOZNA7mwTmHuj1uShSmMQIvSi1G+As0bhCTdBGaodwKHE5CbswQhrDWKldUOiRF/pmDv1I+79IWpxPR7TACwudhf639hoYEw/3hdHfm5uhNyY8RsYLG3LIVwXACGIrThxUs1Us6Mzz1iOYE+q2aOPiHPcGrXprrVkcFjQoV56YRfUxJsvnZcbJqCakWD3cAABpksNkALkjsyGnhBjoC/2LoF/lyXR9D4yE+YBlNDO9fM8QcUf",
+  "build": "build-259",
+  "description": "-smp cores=25 -m 20G",
+  "creationDate": "2025-08-25T07:59:20.933Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-release Sev-SNP MRENCLAVE signature artifact to enable attestation/verification for build 259.
* **Chores**
  * Included metadata (identity, signature, build info, description, creation date) within the artifact.
  * No runtime or UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->