### PR TITLE
Add signature for sev-snp with hash 1d8ff4afb4cde7f01621e1dbdc7f2f567bd14efe806bcc85c7b4d5eeea8998e2

### DIFF
--- a/signatures/sev-snp/pre-release/mrenclave-1d8ff4afb4cde7f01621e1dbdc7f2f567bd14efe806bcc85c7b4d5eeea8998e2.json
+++ b/signatures/sev-snp/pre-release/mrenclave-1d8ff4afb4cde7f01621e1dbdc7f2f567bd14efe806bcc85c7b4d5eeea8998e2.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "1d8ff4afb4cde7f01621e1dbdc7f2f567bd14efe806bcc85c7b4d5eeea8998e2",
+  "signature": "QKn+fDXXaUT9yAHDdbnqT2sMqZZPdqRVa/hLkTTL1SH4D1bwmaTUD/23ui1U5zTsPuCs4wQ3gNofnfdzjpJz6Ha6vpwRWK3RNafBcH+Bm+tmOFAgT7SC76kRxP1jeygjTLe13dwlEd8iO+R8jggorZg8CGMhvd5CMzGhC7PmJrIEluijpbacoutUZ6wvbwj1AXGf1nHrzsBRVugAFvsm610CwCndBAd/42qq5juM/D+TA4wVnk/JsgmmoCPYvP5oyJBFlWjWj3bXtukdkUtYrsk3CLO5DTMexcSKnycLPb3+/gxBRZTxbEUh4wfZec8vTsdmDS8f+rnLmYPqmniXtpoS0L3Es+c5O2h22zPMOs5DBYWAmyDDZLZHxNBF9vt+xhXUnQSWhSXeGgwfRM3pWaremaSVUGDMa0AbR2nukKmg8UngVC8mlJt3vQeDEvwAoNdF/B+t/JTNPCTwmCNrMG5lY2V1dV6Y+t/vjFWdTtJWb9G3fVoOa1mLxS8LSw+8",
+  "build": "build-259",
+  "description": "-smp cores=25 -m 40G",
+  "creationDate": "2025-08-26T09:12:15.323Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a SEV-SNP pre-release attestation artifact to enable verification of the specified MRENCLAVE for build 259. The artifact includes a signature, creation timestamp, and environment description, allowing users to validate enclave measurements for the pre-release environment and improve confidence in secure execution prior to general availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->