### PR TITLE
Add signature for tdx with hash 2f3e72de8c918a8e4b45b32995e38459f59e9d7fcbca94647674012fbb410788

### DIFF
--- a/signatures/tdx/pre-release/mrenclave-2f3e72de8c918a8e4b45b32995e38459f59e9d7fcbca94647674012fbb410788.json
+++ b/signatures/tdx/pre-release/mrenclave-2f3e72de8c918a8e4b45b32995e38459f59e9d7fcbca94647674012fbb410788.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "2f3e72de8c918a8e4b45b32995e38459f59e9d7fcbca94647674012fbb410788",
+  "signature": "xp1zU80JEdfTOZO/sxpNs/sfnwuQWeLIsqY8WcV+Cwm1SFG059KgtjhZXnv5OkpzvA1dCLn9Tu7zCpvjgrQrD9GR0k8+sqH9cPww4c3XF6xLgQX4kDXmceBCga0oyF4M0cBxhuFbmWZQsf+NgIiLjkNvucbO/ooGTEryuuaP6F/9RyQ1Aj5o7NEjgaB+UXtSML9SbWD1fcdjuAe5dD32lEVh7cGprOAUoz4YgaViokvBTMcUcUrDkZsu3FsIjOFUUW+z5cny1+n/c/rN+fQ5tHeVxJUtLuM6cJ1LhArPMzzWkOin9lID0KICqyKe4rufRakKXPI2WTh5xFSm2IAUAY6OFoUkwSZ+RO9ageVIzu04yDcLDRYSJek5UFU9J8JY5ZsIPmEPZzWesGvegDFjybhuzt87AkvT8coBZkKJn8krqXumiaukY10aiTBC91QOc9AIuYjw+mb079QNmAuwsmPfKoaD1ihE5R7UnLnJAaBN0ix40+JX5RAHoMkQczT9",
+  "build": "build-259",
+  "description": "",
+  "creationDate": "2025-08-27T07:58:26.704Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new pre-release TDX enclave signature artifact for build 259, including the MRENCLAVE hash and a base64-encoded signature.
* **Chores**
  * Included associated metadata (creation date and description field) with the signature artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->