### PR TITLE
Add signature for sev-snp with hash 75f69d390974ca151f8fd6d9a5798179cee8035092b39846276254bf2c8aac35

### DIFF
--- a/signatures/sev-snp/pre-release/mrenclave-75f69d390974ca151f8fd6d9a5798179cee8035092b39846276254bf2c8aac35.json
+++ b/signatures/sev-snp/pre-release/mrenclave-75f69d390974ca151f8fd6d9a5798179cee8035092b39846276254bf2c8aac35.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "75f69d390974ca151f8fd6d9a5798179cee8035092b39846276254bf2c8aac35",
+  "signature": "EVvDwTKTn6J59YBIlhb33qs2hqp8F+4QEsxLfAlwLb0Fn2or+qml6baxXapSVAJ3cffHAjfJJhSyVdxS1DtsMdeNDRLPiMlViZHbBMoIeRcdfwFLTI35GdlU8BPdo3s6FxyGSwh11jWsgbOxPvc6rmiw6pWCldzkMENcBl7G+xj/2UrtfEJczK8wM6MoN57iWbAOI3cLzdCfixW44vqseG6yZNRQooL/8cnASX60WwkFdyqKf0N+5N54XLINdAOYwMu9kv+9VXXs6mOv2E3UiU2lRKHASgkcC35vnrA0e8c2jHFV/UEB6+KkF7jL80y3pZwFqDu9bs0B06DvxKdyDF7QbJ9M6Lf8SLMaY8NEtGvqENlVHwr0rcRuN9KMmYJU8K9IlEByOjh3MgzqjZsh/B3fzf1bzf0d1//jLqZPXTWulkyQ/bd+vqa62pYIxmPqzCqXdkD4VjdPs5NoxaOnKaC4thnsboS+aYmpAe7qdgsTkv70egJuCT1stihIUjhT",
+  "build": "build-259",
+  "description": "testnet super-9",
+  "creationDate": "2025-08-28T09:52:06.285Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-release attestation metadata for the testnet “super-9,” enabling clients to verify the latest enclave build.

* **Chores**
  * Included build information and creation timestamp in the new metadata to support verification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->