### PR TITLE
Add signature for sev-snp with hash 1d8677ae519c6460aea3562e7666451de4f0bf95252adbc7dc3403e44220325c

### DIFF
--- a/signatures/sev-snp/pre-release/mrenclave-1d8677ae519c6460aea3562e7666451de4f0bf95252adbc7dc3403e44220325c.json
+++ b/signatures/sev-snp/pre-release/mrenclave-1d8677ae519c6460aea3562e7666451de4f0bf95252adbc7dc3403e44220325c.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "1d8677ae519c6460aea3562e7666451de4f0bf95252adbc7dc3403e44220325c",
+  "signature": "XR6Si3/o1dAxtA3L/ghp+1hZKtRUfG/u74cT/2BEwgVaUYSKcRLf9HNiwR9ubYQZ2pP+1Gw08bh/yGZagiLmramDDSqZOY4VGkXHBMooRpxwv+Z9+cFF1YWk0fEOam4+EFG+spEuFmQdSDvxcTsvfiJx12Z9BqT5VLF5hS7lkt6A12kAvpz6A7fwS0LQlbXNZT8kJEUKD2bLLeGtQXpmJYSc3DnZMxUPYfDGXXLISgp7HiHn2E4b92xcQxVxiN+P1yX8lpY7rSJyFapaaMg0frOehPAwL7QBgyLbmLZWum+fK46Z1s7r3RBckxKEf/jPGfquoe86xtdfX/5QZuEgAiQwPDlmoE2UQ+UyJ9D6krdcO6X9LyAFSntgZt+uXzuqeQSNkZWadp7nvW09L+FbLbebaCfFI/oWrD2gFaD0rYtAX67YGDagJkM8QGdQOrMx0ahtJMhF9TrQqC0xPVdSMr8PpKdDB0/sTrLmwK4D8DeqRJ5zMhlqf9+dKOkVjdmk",
+  "build": "build-259",
+  "description": "testnet super-9",
+  "creationDate": "2025-08-28T10:36:17.180Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Added a pre-release Sev-SNP attestation manifest for the testnet “super-9” (build 259), including enclave measurement, signature, and creation timestamp. This static asset enables users and integrators to verify the build’s attestation in offline workflows or CI pipelines. No application behavior, interfaces, or user workflows were changed. No action required unless you perform attestation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->