### PR TITLE
Add signature for sev-snp with hash a085acfa053002ae0dd4ddd69f3c65c22fae85f0b94c7286f514d139cd7cfdaa

### DIFF
--- a/signatures/sev-snp/pre-release/mrenclave-a085acfa053002ae0dd4ddd69f3c65c22fae85f0b94c7286f514d139cd7cfdaa.json
+++ b/signatures/sev-snp/pre-release/mrenclave-a085acfa053002ae0dd4ddd69f3c65c22fae85f0b94c7286f514d139cd7cfdaa.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "a085acfa053002ae0dd4ddd69f3c65c22fae85f0b94c7286f514d139cd7cfdaa",
+  "signature": "cY4Pya5df2GLVBtKlFxzWMg0CL9U2GVxfxzY6sBIfbDvMj4HTEWVneLIZgzjLaZhJPCkoCFQm+LEOPspj3hcutcc7w+gz9upU3Y0Y6SHA4oJQZEFOGXeK9MwFR9kXpDRieDqO6CDascvoUJrH/MVXMhdV/aGuSAjOk78m1y75J/tSRnnRX+0UWc1rf9bSe4BcfJkQEZLbjLlIlyta+Q7jOL1ySpZSMEYkOxaqZFN39HijCsRp2rM5Byvhbt2jIYqpQzxdvzbSizRRBaWv7Xk1cFbrMGIG3JB3AxOLdKJDsFrZrJkcU/nDiEyseaVKyaf5EhzNw83tC2cLpG2DiNMPFXwNkK8vabY5Bwe0JruR8atGx27Yyiw7K1WsbfxZ7+qtoBCIhHE4+U1vB7k5j68V8Ib6JyY+hD7yLdFM0bNWBGdRWfH00c0czHEPASK95Vj7oF65pNb4OF3gXbViTB66LUpEpM8vV2eTMglcd5IgH/ok8ArLdMZy4kFXtDK8Yrc",
+  "build": "build-260",
+  "description": "argo_branch=sev-test-subroot argo_sp_env=develop sp-debug=true build=build-260 pci=realloc,nocrs",
+  "creationDate": "2025-09-08T17:16:44.736Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-release SEV-SNP signature manifest for a recent enclave build.
  * Manifest includes signature, build identifier, descriptive metadata, and creation timestamp.
  * Available in the pre-release channel for the corresponding build (build 260, dated 2025-09-08).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->