### PR TITLE
Add signature for sev-snp with hash a13da05eab8c029c756793a05ce3188dd35c55156b82aa8ba646104d7371192f

### DIFF
--- a/signatures/sev-snp/pre-release/mrenclave-a13da05eab8c029c756793a05ce3188dd35c55156b82aa8ba646104d7371192f.json
+++ b/signatures/sev-snp/pre-release/mrenclave-a13da05eab8c029c756793a05ce3188dd35c55156b82aa8ba646104d7371192f.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "a13da05eab8c029c756793a05ce3188dd35c55156b82aa8ba646104d7371192f",
+  "signature": "XSwO6iuF+iTVjzOyTRN5GpKU1s6L0F7Fk9m/mU0MeEas0iXWtxJShSiv6K4AfQMV+I5dLpnf/jG8J06kukOLkMcOxfIzrKQsgt/OyaryAxiz+c7/t3DNhY1MWb0bt1FIgeZiNolRjOYkYwKS6obPpKJRNBlUDJ6Asd0y/eqRfAudq0tvHGMAITadSCHAtEuZIMzBWuKezPzLooBusOPos7p84UkPtgYLqGFINQwTvknwbHkC+M9+PbGxPy1LIkTedl9EhKrsadARGgOKlENdwnlm1O60+bMwq+av11mKEMVLQL8+KXKA/qV6JTrCCXstnsv7MqhKyPgnu7gJMyULHPNUmHBSNPWUhobpExPbzcjfytAVz8wddsiDo7jT0cuS1UT76OklDlaCFxgnc6/Akctl+nVdBQl1rSrfkvc4MYNDJNQPGgTXVQON+vek1LrDuD0VQjvSb3a/W3dmE5YWD43yY+zcCOKVDH8W49OV7WjzvuioT6dSv1eOd38/CC6g",
+  "build": "build-261",
+  "description": "argo_branch=sev-test-subroot argo_sp_env=develop sp-debug=true build=build-261 pci=realloc,nocrs",
+  "creationDate": "2025-09-10T09:06:04.316Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new pre-release SEV-SNP attestation artifact for build 261.
  * The artifact includes an enclave measurement hash, a corresponding signature, build label, descriptive metadata, and an ISO-8601 creation timestamp.
  * This change introduces only a static data file; no code, configuration, or runtime behavior was modified.
  * No impact to UI or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->