### PR TITLE
Add signature for sev-snp with hash ac26a2094a15ec38aac808df18dd66784172bd0e56ab4c48c5dcfcc83bde65ab

### DIFF
--- a/signatures/sev-snp/pre-release/mrenclave-ac26a2094a15ec38aac808df18dd66784172bd0e56ab4c48c5dcfcc83bde65ab.json
+++ b/signatures/sev-snp/pre-release/mrenclave-ac26a2094a15ec38aac808df18dd66784172bd0e56ab4c48c5dcfcc83bde65ab.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "ac26a2094a15ec38aac808df18dd66784172bd0e56ab4c48c5dcfcc83bde65ab",
+  "signature": "kDIFM9NlNhRs/pk06PvptVke0/4V9LXbWlNjIUiWBo9fperSO1ZxHs2yVaBuHq0Xx3CDpMMCS46MyD9DTCd38zwmr3ac2b144ePvBbjGj6T+8rFXn7H5zxReTR5VxymvACC+DBTBLAQnD7Jrx+JyrOkD7coK5ZyPnirQ9PQOfiwUuwBYcmYaU950Pr8B5oS1jitMw5rDcLqSvDPRgMeEzYBQLZWcVyaSAhwm7qkaVxcuccC7jrXEQZHhrKLO4FGFQqp3pU4iFtty8EktfDIyWU7fe24Dvab5NAY2LCWViJijmBs6Tsv0m27TNGLSAwAn4/t+p4BSyquwd55VZbLjQOkNlOU/Fo7/IbWUT+LvmyikDBgJDxC3NOvuLKOdCV5jg5ah7AvFdUcAu+XrkpUdX51pR4h6NDXQtePLgZWwazDvDutV5cg9hnfpYAq65wvZGdJXPGtYVyOLuj+aO3lZyPu3SmDu9yup7KXUQlNaWMQUTd++T5Ti4kFwP65AkLVF",
+  "build": "build-266",
+  "description": "argo_branch=sev-test-subroot argo_sp_env=develop sp-debug=true build=build-266 pci=realloc,nocrs",
+  "creationDate": "2025-09-11T17:50:47.541Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Added a new SEV-SNP pre-release attestation artifact for build 266, including signature and metadata to facilitate verification in development environments.
  * This update is data-only and does not alter application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->