### PR TITLE
Add signature for tdx with hash fa52d555b978fc4ae12a00924e4fac54724c1fba8fe384a910537c2edeb09eb8

### DIFF
--- a/signatures/tdx/pre-release/mrenclave-fa52d555b978fc4ae12a00924e4fac54724c1fba8fe384a910537c2edeb09eb8.json
+++ b/signatures/tdx/pre-release/mrenclave-fa52d555b978fc4ae12a00924e4fac54724c1fba8fe384a910537c2edeb09eb8.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "fa52d555b978fc4ae12a00924e4fac54724c1fba8fe384a910537c2edeb09eb8",
+  "signature": "x3r4l+/VffQTtHjMQg3bkFM5gxOBkiZJBF3pGvSS0N1+eM3dc3n95PBldNzJ0vUvmCl0wdVtiFOBOhZKJiuf+wPnnLECcsfEW9n/b+cs3t5d5DgpyVj/MIGYw1uUnLVJs8KxidVWWTflYwtMChEzrRETjDeIWDfUWtb/sZzkHDbIsysMqgL4azjuejA9uFVkXOXhZBNLEAJPuu3BLTe8faPXgIKlW4f4rZUPeSxA1lPFaJ9N3aAvP86RqFK1CB9WEEXDgy97DYOJueqFXjWJ/fEPpM14szw5FCwcJ3qFtdfVIQNgPIdbGkZ9w8szgqk0m4dASnBWSKgUIVyKz/mvdeUD7fLqGf6wThaTmDdm76PBjLnkfabLrc8HlZ7yoWA1HmFGPOKsDdLnXGpROQBi0Zhwf3AarizpJOb8fdJvTC3ySO3XGOC3nrN17MqmYpKWdLpRJgpZ1VwxFZD1gwSYFAROvfsM5zKoiP1daGetOLaQ8ptLyLSOlYcIv5yJAoC/",
+  "build": "build-265",
+  "description": "",
+  "creationDate": "2025-09-12T14:08:01.971Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pre-release TDX attestation metadata for enclave build 265, including MRENCLAVE digest, signature, and creation date to support verification by clients and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->