### PR TITLE
Increasing kublet log size

### DIFF
--- a/src/rootfs/files/configs/etc/rancher/rke2/config.yaml.tmpl
+++ b/src/rootfs/files/configs/etc/rancher/rke2/config.yaml.tmpl
@@ -1,7 +1,7 @@
 kubelet-arg:
   - max-pods=256
-  - container-log-max-files=5
-  - container-log-max-size=500Mi
+  - container-log-max-files=20
+  - container-log-max-size=20Mi
 disable:
   - rke2-ingress-nginx
   - rke2-metrics-server


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adjusted kubelet log rotation limits: container logs now capped at 20 files with a maximum size of 20Mi each to reduce uncontrolled log growth.
  * Helps prevent excessive disk usage and improves cluster stability by capping log growth.

* **Chores**
  * Updated configuration to apply the revised kubelet log limits; no other operational settings changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->