### PR TITLE
Add signature for tdx with hash 6927e1848d0b7d5e9508e9b8bf4e8e1e56c668b21abe4b17ea3c268afe3f7e15

### DIFF
--- a/signatures/tdx/pre-release/mrenclave-6927e1848d0b7d5e9508e9b8bf4e8e1e56c668b21abe4b17ea3c268afe3f7e15.json
+++ b/signatures/tdx/pre-release/mrenclave-6927e1848d0b7d5e9508e9b8bf4e8e1e56c668b21abe4b17ea3c268afe3f7e15.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "6927e1848d0b7d5e9508e9b8bf4e8e1e56c668b21abe4b17ea3c268afe3f7e15",
+  "signature": "XX6rnsFckpFjL893Y9OKTYJ7qhxNFqdkxlngUlvI6P60OAj9rZgYUdZ+laNCwsITbNSljlIoOXb4dn3DCQVWq9ppz3T+HlwmUMLpFd+gYKeg1o4jpwmq0LGVXjC0uCP409oDRA6nuimL7V/WZpwDI4Yb4z663d2+AiMAwVegIEHoiXOKxYQvBCiNmGqZyvRuP031RoLmFO7I23MzgY6/bSDQnkoEDh422YlqKL5hhS4jrDlnj36z1MT5zbruHJ7Op+Iu3zo1yVxkLkq6sZJ+BqLN5zxG8PrC1ZyT+rwRBzgfbMsY05fZcVljy8HN77xoYeCy8huGcGJU+msHe6Y5O8Bc/W5uMPKTSbfNQfHZYZtNZ9MbP7Ckec1B5SvY2pS6t2DUpddCgQBZEmBgp8WLc4HOIgVBN7T+PyujxzFAFIP6UPvoZF1ovQmB+4aecfYbPBtH2tZGtKmv+9taUggizAAYumcbWVADjQw9RXxS3C+GXGoJBVF08h6CUt1ktRc4",
+  "build": "build-270",
+  "description": "",
+  "creationDate": "2025-09-19T08:40:25.760Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Added a new pre-release TDX attestation signature for build 270, including mrenclave and signature metadata with a recent creation date.
  * Expanded the pre-release attestation catalog to include the latest enclave measurement record, ensuring consistency across environments.
  * No changes to user interface or workflows; this update refreshes pre-release verification data only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->