### PR TITLE
Add signature for tdx with hash 6ecaa705043b4931381b5b5b5bb2f0db1a9291cf801d444d4f3de544055d49b4

### DIFF
--- a/signatures/tdx/pre-release/mrenclave-6ecaa705043b4931381b5b5b5bb2f0db1a9291cf801d444d4f3de544055d49b4.json
+++ b/signatures/tdx/pre-release/mrenclave-6ecaa705043b4931381b5b5b5bb2f0db1a9291cf801d444d4f3de544055d49b4.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "6ecaa705043b4931381b5b5b5bb2f0db1a9291cf801d444d4f3de544055d49b4",
+  "signature": "BGk2ADR2FH/Gy9i+qIBG7BHL7LF14qvl0V4eJ+U6nh/Zxw/QddjB+hjHu1ILTDX9NyeQ6keLcLas8Rfk7O6rMQfF307ffjMMrSRbEXP72rBmXi10sKxGbnIUwPXFlb9YsXPxr0o1rTb2lpT4FHBSwCy/QaeUm7aKL/EujOhlze3zhFarPskORtvlTaJAG+7jOTOCqiHRauGbaYoocRytSpSX7Rdw6F42Jh3c4fLFt5YnWgnMqM9w9qG2dCRImw7yXs9xI0Akr2NPCL6LPEg5Mw4y+YiXjzK7oPhkQ+5omJAJcv2kA/Pa9jzCU8xPtkFaQ+tUCNKun3ZkEjbMzqa4GyZVv5r+tgfinhXJezOoZv7N5aT9LG83KsGsFtmgdvMHPPeOfkgqW80ogCV8IHN/tDJLVodh8RsPU/erdcnAk7SXYpL2bZXp5oTLJnXExUrwsQINKel9BfASC3mxLW/gpVLXIqix0FQm37V6bhFCL/Tz3Umjk91vWgVXqodFoVgJ",
+  "build": "build-270",
+  "description": "",
+  "creationDate": "2025-09-22T09:06:36.750Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a pre-release TDX attestation metadata JSON file.
  * Includes fields: mrenclave, signature, build, description, and creationDate.
  * Located under signatures/tdx/pre-release and versioned by the mrenclave hash.
  * Provides a consumable artifact for users needing standardized attestation metadata across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->