### PR TITLE
Add signature for sev-snp with hash 5e28dfe15a7e4ac0cd0a1a78f0b0acaab2dfc2f464243d6722164b927ba6cd70

### DIFF
--- a/signatures/sev-snp/pre-release/mrenclave-5e28dfe15a7e4ac0cd0a1a78f0b0acaab2dfc2f464243d6722164b927ba6cd70.json
+++ b/signatures/sev-snp/pre-release/mrenclave-5e28dfe15a7e4ac0cd0a1a78f0b0acaab2dfc2f464243d6722164b927ba6cd70.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "5e28dfe15a7e4ac0cd0a1a78f0b0acaab2dfc2f464243d6722164b927ba6cd70",
+  "signature": "UlZxwigZNa4KiqBmm7lfb5mjEsfPAuEG8C3WvRGMnkD4Nk90uKMvlzuJYhDMP7ttnVG/tQggBBU44eL3IeEwP5aConul0py7BeAMQFsgdgTgYXR5P6CtBpadFvq4WCZNCuXetPZmN1RLUxQx9aVWLz8R1yWvYDzV9lkf2w6ot32OFozzo835BGC+wxaiBBFwfTQQXAVlfcL3m2vA6KFsD53A1mSUZ4tjUHFbcLI87Sc5hv6j+7IL5fstLOO9n3r8oiPDnxSQl9uffmKExU9zsh2Ho3WCAdVhhrMV0+rk5GVGaY/1/4NcPnyUtYAmAc0BcLufSwxBM7g5KBtwfpy55BKfWZYyAA6Sh+/WLV8cSBxgx87mOCbkIJwsljn3AaO5qre1DggbbbXRLYwOD7ESuaN/tgIThwwrwNL7ShyJGZHkNnkciDkWq7QKQld+FDySMTjRaMWAZumtg7JcX72fiqN9U5QvR31noa6gws7L2vC1+J1ifayA9t8ffDjp4oVo",
+  "build": "build-270",
+  "description": "debug,testnet",
+  "creationDate": "2025-10-02T12:28:09.881Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a pre-release SEV-SNP enclave signature for testnet build 270, enabling attestation/verification in debug and testnet environments.

* Chores
  * Refreshed signature catalog with the latest build metadata to ensure compatibility with current testnet deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->