### PR TITLE
Use actual random key instead of literal string in state disk mount

### DIFF
--- a/src/rootfs/files/configs/state_disk_mount/state_disk_mount.sh
+++ b/src/rootfs/files/configs/state_disk_mount/state_disk_mount.sh
@@ -66,8 +66,8 @@ fi
 STATE_BLOCK_DEVICE_PATH="/dev/$STATE_BLOCK_DEVICE_NAME";
 RANDOM_KEY="$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64)";
 wipefs -a "$STATE_BLOCK_DEVICE_PATH" || true;
-echo "\$RANDOM_KEY" | cryptsetup luksFormat "$STATE_BLOCK_DEVICE_PATH" --batch-mode;
-echo "\$RANDOM_KEY" | cryptsetup luksOpen "$STATE_BLOCK_DEVICE_PATH" crypto;
+echo "$RANDOM_KEY" | cryptsetup luksFormat "$STATE_BLOCK_DEVICE_PATH" --batch-mode;
+echo "$RANDOM_KEY" | cryptsetup luksOpen "$STATE_BLOCK_DEVICE_PATH" crypto;
 mkfs.ext4 "/dev/mapper/crypto";
 
 # Mounting read-only provider config


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed encrypted state disk setup to correctly use random encryption keys during initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->