### PR TITLE
Add DHCP firewall rule for LXC containers

### DIFF
--- a/src/rootfs/files/configs/usr/local/bin/hardening-vm.sh
+++ b/src/rootfs/files/configs/usr/local/bin/hardening-vm.sh
@@ -26,6 +26,9 @@ if ! grep -q 'sp-debug=true' /proc/cmdline; then
     iptables -I INPUT -s 10.43.0.0/16 -j ACCEPT
     iptables -I INPUT -s 10.42.0.0/16 -j ACCEPT
 
+    # Allow DHCP for LXC containers (client:68 -> server:67)
+    iptables -A INPUT -i lxcbr0 -p udp --sport 68 --dport 67 -j ACCEPT
+
 #if DEBUG, then make vm accesable from SSH, and TTY terminal
 else
     # Start services


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled DHCP traffic support for LXC containers by updating firewall configuration to allow necessary network traffic on the bridge interface, ensuring proper IP address assignment for containerized environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->