### PR TITLE
fix: update kernel source download script to use new URL and checksum format

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -103,6 +103,7 @@ RUN gen_init_cpio /initramfs-root/initramfs.list | gzip -9 -n > /initramfs-root/
 FROM ubuntu:24.04 AS kernel_builder
 RUN apt-get update && apt-get install -y wget gcc make build-essential curl libssl-dev bc elfutils libelf-dev bison flex cpio kmod rsync debhelper
 ARG KERNEL_VERSION=6.12.13
+ARG KERNEL_SHA256=191dc5aae14a4223f0d5ce4e88cbbd29f0377703b9f0b70d4903734de641fb6a
 
 WORKDIR /buildroot
 

--- a/src/kernel/files/scripts/download_and_verify_kernel_src.sh
+++ b/src/kernel/files/scripts/download_and_verify_kernel_src.sh
@@ -5,6 +5,7 @@ set -euo pipefail;
 
 # public, required
 # KERNEL_VERSION
+# KERNEL_SHA256
 
 # private
 BUILDROOT="/buildroot";
@@ -29,10 +30,10 @@ function download_kernel() {
 }
 
 function download_kernel_checksums() {
-    log_info "downloading kernel checksums"
-    echo "191dc5aae14a4223f0d5ce4e88cbbd29f0377703b9f0b70d4903734de641fb6a  linux-$KERNEL_VERSION.tar.gz" \
+    log_info "preparing kernel checksums"
+    echo "$KERNEL_SHA256  linux-$KERNEL_VERSION.tar.gz" \
         > "$BUILDROOT/src/linux-$KERNEL_VERSION.sha256" \
-        || log_fail "failed to download kernel checksums";
+        || log_fail "failed to prepare kernel checksums";
 }
 
 function verify_kernel_checksum() {

--- a/src/kernel/files/scripts/download_and_verify_kernel_src.sh
+++ b/src/kernel/files/scripts/download_and_verify_kernel_src.sh
@@ -8,7 +8,6 @@ set -euo pipefail;
 
 # private
 BUILDROOT="/buildroot";
-KERNEL_VERSION_MAJOR="$(awk -F '.' '{print $1}' <<< "$KERNEL_VERSION")";
 
 # init loggggging;
 source "$BUILDROOT/files/scripts/log.sh";
@@ -24,19 +23,15 @@ function download_kernel() {
     curl \
         -Ss \
         --fail \
-        "https://cdn.kernel.org/pub/linux/kernel/v$KERNEL_VERSION_MAJOR.x/linux-$KERNEL_VERSION.tar.xz" \
-        > "$BUILDROOT/src/linux-${KERNEL_VERSION}.tar.xz"\
+        "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot/linux-$KERNEL_VERSION.tar.gz" \
+        > "$BUILDROOT/src/linux-${KERNEL_VERSION}.tar.gz"\
         || log_fail "failed to download kernel";
 }
 
 function download_kernel_checksums() {
     log_info "downloading kernel checksums"
-    curl \
-        -Ss \
-        --fail \
-        "https://cdn.kernel.org/pub/linux/kernel/v$KERNEL_VERSION_MAJOR.x/sha256sums.asc" \
-        | grep "linux-$KERNEL_VERSION.tar.xz" \
-            > "$BUILDROOT/src/linux-$KERNEL_VERSION.sha256" \
+    echo "191dc5aae14a4223f0d5ce4e88cbbd29f0377703b9f0b70d4903734de641fb6a  linux-$KERNEL_VERSION.tar.gz" \
+        > "$BUILDROOT/src/linux-$KERNEL_VERSION.sha256" \
         || log_fail "failed to download kernel checksums";
 }
 
@@ -51,7 +46,7 @@ function verify_kernel_checksum() {
 function unarchive_kernel() {
     log_info "unarchiving kernel";
     pushd "$BUILDROOT/src";
-    tar -xf "linux-$KERNEL_VERSION.tar.xz";
+    tar -xf "linux-$KERNEL_VERSION.tar.gz";
     popd;
 }
 


### PR DESCRIPTION
Replaced the kernel source download URL to point to the Git repository and updated the checksum handling to reflect the new tar.gz format instead of tar.xz. This change ensures compatibility with the latest kernel source distribution.