### PR TITLE
Add signature for tdx with hash 987487403c966b0d696de4d4604973735ab671b5067a61b2b5d14536c2c68320

### DIFF
--- a/signatures/tdx/pre-release/mrenclave-987487403c966b0d696de4d4604973735ab671b5067a61b2b5d14536c2c68320.json
+++ b/signatures/tdx/pre-release/mrenclave-987487403c966b0d696de4d4604973735ab671b5067a61b2b5d14536c2c68320.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "987487403c966b0d696de4d4604973735ab671b5067a61b2b5d14536c2c68320",
+  "signature": "KwCy4xHgaFoV8KLzc1x8GT9PpanJRMkDUHnE9o0iAWfovwrThJxmnNWx/l5k2tlKnQPMAksM3IC0oWJOwqSoYkzLU6l3GeO2sAyG9sjcCjjEnCoDrxD4R60weI6z1Pt2rjgESrDZ7AoAH80Pwx8pSuU1hFnBZTnuy+uTT5FHQ2ElVaSTwC1DeygdbE6e0B2ZpueD1eCwS2MPVnNsijk6QRxOPT+E0TZl01q4UFufPeix5UIYTMwCoZuYEXw0GVbh+yOzpNzbngHhUszdatB8qL3eq1i3yRId8ga6g2oxaeGSDItHlYYMEQHuQ1YoPjfeAu6PoeNCdECt4mL0UKDo+YvZ82vX+I7FqX7hMYe/1A0CMNbjahOZd6AumiFXSAO66nqZeDRkks8qPerx+dGk/t3K9NUdvoB4lOka7MBEES/H8eY7uJxmsKvAMSl1NSDao6J8xEgMOByiw3YkLnoS6GaAmNFg/Xic8Cu8Ko+aEsgR434R9V2RkTOaUmKqbGjw",
+  "build": "build-381-release",
+  "description": "",
+  "creationDate": "2026-07-09T14:11:25.102Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-release TDX mrenclave signature entry with its associated hash, signature, build ID, description, and creation timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->