### PR TITLE
Add signature for tdx with hash 298fdc679e7738ae0d63908b8d405b7cd8dcdaebd88ba1ad10206c1ae65943f4

### DIFF
--- a/signatures/tdx/pre-release/mrenclave-298fdc679e7738ae0d63908b8d405b7cd8dcdaebd88ba1ad10206c1ae65943f4.json
+++ b/signatures/tdx/pre-release/mrenclave-298fdc679e7738ae0d63908b8d405b7cd8dcdaebd88ba1ad10206c1ae65943f4.json
@@ -1,0 +1,7 @@
+{
+  "mrenclave": "298fdc679e7738ae0d63908b8d405b7cd8dcdaebd88ba1ad10206c1ae65943f4",
+  "signature": "dVSAEhdsSt8bPyprsiEdW8rdcUCWIaxsqt/GJRY6l9XzBGqunfU1HR4YnTx7Psnh80oO2rjyXR3wX4NAGTbfSCID3x2uO+q/62GfFpNdLe+T5ZRKk70lJF1A3SnjIcF8bjJiwKPoeRXnTHYdPImKnkiofK+kc3g5rluXgBkq9at0OnbCrAEXvHTNgZ28Nimgzf77HRnpJG8TH8LEiKnEcxalnBwubIdhs7JfMYeojRb66pO5tmRPyLUJxz8xOSAPMZLcARbpTom/CKFXebK/kCTqIyf6xkNlRS0p3x8qCsmtKUoW7wnf5N3n3/HM1GLAflewWu5aNW6Vig6gPpzll9SWGEw6KZdLbIUYuPXAOZbTII1lwXOXysoZjR3bavUpOMXswtqpGbbR+Xc4HtS7p9lsr6J76TUDgPinBsm3+2tI7Z4FBKsNrvhNCyb4TEiAUCco3R9sQBbOUTM69qRPCRPX8mqQwb/D7Gp1NJvdNZ68EWKFgdmS8nthOBFGPusK",
+  "build": "build-382-release",
+  "description": "",
+  "creationDate": "2026-07-10T12:23:04.649Z"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a pre-release signature descriptor for the TDX build.
  * Associated the signature with `build-382-release` and recorded its creation date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->